### PR TITLE
feat: Add Sequelize migrations, seeders, and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Database Configuration
+DB_HOST=localhost
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_NAME=pbuddy_db
+
+# Application Port
+PORT=3000
+
+# Ollama Configuration (optional, defaults to http://localhost:11434)
+# OLLAMA_HOST=http://localhost:11434
+
+# Database Pool Configuration for Production (optional, for sequelize-config.js)
+# DB_POOL_MAX_PROD=5
+# DB_POOL_MIN_PROD=0
+# DB_POOL_ACQUIRE_PROD=30000
+# DB_POOL_IDLE_PROD=10000
+
+# Test Database Configuration (optional, for sequelize-config.js if running tests)
+# DB_USER_TEST=
+# DB_PASSWORD_TEST=
+# DB_NAME_TEST=pbuddy_db_test
+# DB_HOST_TEST=localhost

--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = {
+  'config': path.resolve('config', 'sequelize-config.js'),
+  'models-path': path.resolve('models'), // We already have this path from before
+  'migrations-path': path.resolve('migrations'),
+  'seeders-path': path.resolve('seeders'),
+};

--- a/README.md
+++ b/README.md
@@ -1,2 +1,141 @@
-# pbuddy
-a personal buddy (ai) which works on the nodejs. 
+# PBuddY - Personal AI Buddy
+
+PBuddY is a Node.js application that acts as a personal AI assistant, leveraging a locally running Ollama instance for AI chat functionalities. It provides a REST API to manage users, chat sessions, and interactions with the AI.
+
+## Features
+
+*   User management (creation)
+*   Chat session creation and retrieval
+*   Message handling within chat sessions
+*   Integration with a local Ollama service for AI responses
+*   Token counting for chat context management
+*   Database schema management using Sequelize migrations
+*   Sample data seeding
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+*   **Node.js:** Version 18.x or higher recommended.
+*   **npm:** (Usually comes with Node.js).
+*   **MySQL:** A running MySQL server instance.
+*   **Ollama:**
+    *   Ollama installed and running locally. Download from [ollama.com](https://ollama.com/).
+    *   At least one model pulled, e.g., `llama2` or `mistral`. You can pull a model by running:
+        ```bash
+        ollama pull llama2
+        ```
+
+## Installation
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/IamFishR/pbuddy.git
+    cd pbuddy
+    ```
+
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+
+## Environment Setup
+
+1.  **Create a `.env` file** in the root of the project by copying the example:
+    ```bash
+    cp .env.example .env
+    ```
+    *(Note: I will create `.env.example` in the next step, as it wasn't explicitly part of the plan but is good practice for READMEs like this.)*
+
+2.  **Configure your `.env` file** with your local settings:
+    ```
+    DB_HOST=localhost
+    DB_USER=your_mysql_user
+    DB_PASSWORD=your_mysql_password
+    DB_NAME=pbuddy_db
+    PORT=3000
+
+    # Ollama API endpoint (if different from default http://localhost:11434)
+    # OLLAMA_HOST=http://localhost:11434
+    ```
+    Replace `your_mysql_user` and `your_mysql_password` with your MySQL credentials. The `DB_NAME` will be created if it doesn't exist when migrations are run.
+
+## Database Setup
+
+1.  **Ensure your MySQL server is running.**
+
+2.  **Create the database (if it doesn't exist):**
+    You can manually create the database specified in your `.env` file (e.g., `pbuddy_db`) using a MySQL client:
+    ```sql
+    CREATE DATABASE pbuddy_db;
+    ```
+    Alternatively, the first migration run might create it if your MySQL user has sufficient privileges, but manual creation is safer.
+
+3.  **Run database migrations:**
+    This command will create all the necessary tables in your database according to the schema.
+    ```bash
+    npm run db:migrate
+    ```
+
+4.  **Run database seeders (optional but recommended for initial testing):**
+    This command will populate the database with some sample data (e.g., test users).
+    ```bash
+    npm run db:seed:all
+    ```
+
+## Running the Application
+
+1.  **Start the application:**
+    ```bash
+    npm start
+    ```
+    The server will start, typically on port 3000 (or the port specified in your `.env` file). You should see a message like `Server is listening on port 3000`.
+
+2.  **Ensure Ollama is running:**
+    Make sure your local Ollama service is active and the model you intend to use (default `llama2` or specified in API calls) is available.
+
+## Basic API Endpoints
+
+Here are some of the main API endpoints to get you started:
+
+*   **Create a User:**
+    *   `POST /api/users`
+    *   Body: `{ "username": "your_username" }`
+
+*   **Create a Chat:**
+    *   `POST /api/chats`
+    *   Body: `{ "userId": 1 }` (replace `1` with an actual user ID)
+
+*   **Send a Message to a Chat:**
+    *   `POST /api/chats/:chatId/messages` (replace `:chatId` with an actual chat ID)
+    *   Body: `{ "userId": 1, "content": "Hello, AI!", "model": "llama2" }` (model is optional, defaults to llama2)
+
+*   **Get Messages for a Chat:**
+    *   `GET /api/chats/:chatId/messages`
+
+*   **Get User Details:**
+    *   `GET /api/users/:userId`
+
+*   **Get Chat Details:**
+    *   `GET /api/chats/:chatId`
+
+*   **Get All Chats for a User:**
+    *   `GET /api/chats/user/:userId`
+
+## Development
+
+*   To run the server with `nodemon` for automatic restarts on file changes (if you have it installed globally or add it to devDependencies):
+    ```bash
+    npm run dev
+    ```
+
+*   **Undoing migrations/seeds:**
+    *   `npm run db:migrate:undo` (undo the last migration)
+    *   `npm run db:migrate:undo:all` (undo all migrations)
+    *   `npm run db:seed:undo:all` (undo all seeds)
+
+## Ollama Service Notes
+
+*   The application expects your Ollama service to be running at `http://localhost:11434` by default. If it's different, set the `OLLAMA_HOST` variable in your `.env` file.
+*   Ensure the AI models you wish to use (e.g., `llama2`, `mistral`) are pulled into your Ollama instance. You can list your local models with `ollama list`.
+```

--- a/config/sequelize-config.js
+++ b/config/sequelize-config.js
@@ -1,0 +1,38 @@
+require('dotenv').config({ path: '../.env' }); // Adjust path if .sequelizerc is in a different location relative to .env
+
+module.exports = {
+  development: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    dialect: 'mysql',
+    pool: { // Optional: Add pool configuration if needed for CLI operations, though usually less critical here
+      max: 5,
+      min: 0,
+      acquire: 30000,
+      idle: 10000
+    }
+  },
+  test: {
+    username: process.env.DB_USER_TEST || process.env.DB_USER, // Example: use specific test DB env vars if available
+    password: process.env.DB_PASSWORD_TEST || process.env.DB_PASSWORD,
+    database: process.env.DB_NAME_TEST || `${process.env.DB_NAME}_test`,
+    host: process.env.DB_HOST_TEST || process.env.DB_HOST,
+    dialect: 'mysql'
+  },
+  production: {
+    username: process.env.DB_USER_PROD || process.env.DB_USER,
+    password: process.env.DB_PASSWORD_PROD || process.env.DB_PASSWORD,
+    database: process.env.DB_NAME_PROD || process.env.DB_NAME,
+    host: process.env.DB_HOST_PROD || process.env.DB_HOST,
+    dialect: 'mysql',
+    // Add other production specific options like SSL, pool size etc.
+    pool: {
+      max: process.env.DB_POOL_MAX_PROD || 5,
+      min: process.env.DB_POOL_MIN_PROD || 0,
+      acquire: process.env.DB_POOL_ACQUIRE_PROD || 30000,
+      idle: process.env.DB_POOL_IDLE_PROD || 10000
+    }
+  }
+};

--- a/index.js
+++ b/index.js
@@ -62,11 +62,22 @@ app.use((err, req, res, next) => {
   res.status(statusCode).json(responseError);
 });
 
-// Sync database and start server
-db.syncDb().then(() => {
-  app.listen(port, () => {
-    console.log(`Server is listening on port ${port}`);
+// Start server (database sync is now handled by migrations)
+// We might want to add a check to ensure DB connection is alive before starting
+// For now, let's directly start the server.
+// A more robust approach would be to test the DB connection using db.sequelize.authenticate()
+
+db.sequelize.authenticate()
+  .then(() => {
+    console.log('Database connection has been established successfully.');
+    app.listen(port, () => {
+      console.log(`Server is listening on port ${port}`);
+      console.log(`Remember to run 'npm run db:migrate' if you haven't already.`);
+    });
+  })
+  .catch(err => {
+    console.error('Unable to connect to the database:', err);
+    console.error('Please ensure your database server is running and configuration is correct.');
+    console.error("If this is the first time, you might need to run 'npm run db:migrate'");
+    process.exit(1); // Exit if DB connection fails
   });
-}).catch(err => {
-    console.error('Failed to start the server:', err);
-});

--- a/migrations/20250706184830-initial-tables.js
+++ b/migrations/20250706184830-initial-tables.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    // Create Users table
+    await queryInterface.createTable('Users', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      username: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+
+    // Create Chats table
+    await queryInterface.createTable('Chats', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users', // Name of the target table
+          key: 'id',      // Name of the target column
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE', // Or 'SET NULL' or 'RESTRICT' depending on desired behavior
+      },
+      tokenCount: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+
+    // Create Messages table
+    await queryInterface.createTable('Messages', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      chatId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Chats', // Name of the target table
+          key: 'id',      // Name of the target column
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      sender: {
+        type: Sequelize.ENUM('user', 'bot'),
+        allowNull: false,
+      },
+      content: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      tokenCount: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      timestamp: { // This was `timestamp` in model, ensure consistency
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    // Drop tables in reverse order of creation due to foreign key constraints
+    await queryInterface.dropTable('Messages');
+    await queryInterface.dropTable('Chats');
+    await queryInterface.dropTable('Users');
+  }
+};

--- a/models/index.js
+++ b/models/index.js
@@ -61,7 +61,8 @@ db.Message.belongsTo(db.Chat, {
   as: 'chat'
 });
 
-// Function to sync database
+// Function to sync database - This will now be handled by migrations
+/*
 db.syncDb = async () => {
   try {
     // await sequelize.sync({ force: true }); // Drops and recreates tables - use for development
@@ -72,5 +73,6 @@ db.syncDb = async () => {
     process.exit(1); // Exit if DB sync fails
   }
 };
+*/
 
 module.exports = db;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "a personal buddy (ai) which works on the nodejs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js",
+    "dev": "nodemon index.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "db:migrate": "npx sequelize-cli db:migrate",
+    "db:migrate:undo": "npx sequelize-cli db:migrate:undo",
+    "db:migrate:undo:all": "npx sequelize-cli db:migrate:undo:all",
+    "db:seed:all": "npx sequelize-cli db:seed:all",
+    "db:seed:undo:all": "npx sequelize-cli db:seed:undo:all"
   },
   "repository": {
     "type": "git",
@@ -24,5 +31,9 @@
     "mysql2": "^3.14.1",
     "ollama": "^0.5.16",
     "sequelize": "^6.37.7"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.10",
+    "sequelize-cli": "^6.6.3"
   }
 }

--- a/seeders/20250706184942-sample-users.js
+++ b/seeders/20250706184942-sample-users.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const users = [
+      {
+        username: 'testuser1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        username: 'testuser2',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        username: 'ollama_tester',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+    ];
+
+    // Check if users already exist to prevent duplicate entries if seeder runs multiple times
+    // This is a simple check; more complex logic might be needed for more robust idempotency
+    const existingUsers = await queryInterface.sequelize.query(
+      `SELECT username FROM "Users" WHERE username IN (:usernames)`,
+      {
+        replacements: { usernames: users.map(u => u.username) },
+        type: queryInterface.sequelize.QueryTypes.SELECT
+      }
+    );
+
+    const existingUsernames = existingUsers.map(u => u.username);
+    const usersToInsert = users.filter(u => !existingUsernames.includes(u.username));
+
+    if (usersToInsert.length > 0) {
+      await queryInterface.bulkInsert('Users', usersToInsert, {});
+      console.log(`Seeded ${usersToInsert.length} users.`);
+    } else {
+      console.log('Users already seeded or no new users to seed.');
+    }
+  },
+
+  async down (queryInterface, Sequelize) {
+    // Remove only the specific users seeded, or all users if that's desired.
+    // For this example, we'll remove the specific users.
+    const usernamesToDelete = ['testuser1', 'testuser2', 'ollama_tester'];
+    await queryInterface.bulkDelete('Users', {
+      username: {
+        [Sequelize.Op.in]: usernamesToDelete,
+      },
+    }, {});
+    console.log(`Removed sample users: ${usernamesToDelete.join(', ')}`);
+  }
+};


### PR DESCRIPTION
- Configure Sequelize CLI and set up config to use environment variables.
- Create initial migration for Users, Chats, and Messages tables.
- Update application to use migrations instead of `sequelize.sync()`.
- Add npm scripts for database migration and seeding.
- Create a seeder for sample users.
- Comprehensively update README.md with setup, installation, and usage instructions.
- Add `.env.example` for environment variable guidance.
- Add `nodemon` as a dev dependency for `npm run dev` script.